### PR TITLE
Fix service worker path

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1316,7 +1316,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Register Service Worker
     if ('serviceWorker' in navigator) {
         try {
-            const registration = await navigator.serviceWorker.register('/service-worker.js');
+            // Use a relative path for GitHub Pages compatibility
+            const registration = await navigator.serviceWorker.register('./service-worker.js');
             debugLog('Service Worker registered with scope: ' + registration.scope, 'info');
         } catch (error) {
             debugLog('Service Worker registration failed: ' + error, 'error');


### PR DESCRIPTION
## Summary
- use a relative path when registering the service worker so it works on GitHub Pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6876e84190f4832a9fe4557b60b22fae