### PR TITLE
Enhance UX and profile validation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -460,6 +460,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  overflow-y: auto;
 }
 
 .conversation-item {
@@ -487,6 +488,25 @@ body {
   background: var(--bg-active);
   color: var(--accent-primary);
   border-left: 3px solid var(--accent-primary);
+}
+
+.conv-title {
+  font-weight: bold;
+  display: block;
+}
+
+.conv-snippet {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.conv-time {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-align: right;
 }
 
 .sidebar-footer {
@@ -985,6 +1005,13 @@ kbd {
 
 .typing-indicator i:nth-child(3) {
   animation-delay: 0.4s;
+}
+
+.char-count {
+  margin-left: 12px;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  float: right;
 }
 
 @keyframes typing {
@@ -1873,6 +1900,22 @@ body.light-mode .sidebar-btn:hover {
 
 .copy-message-btn:hover {
     color: var(--accent-primary);
+}
+
+.retry-btn {
+    background: var(--bg-hover);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 4px 8px;
+    color: var(--text-primary);
+    cursor: pointer;
+    margin-left: 8px;
+    font-size: 0.8rem;
+}
+
+.retry-btn:hover {
+    background: var(--accent-primary);
+    color: var(--bg-primary);
 }
 
 /* Placeholder icon or message when chat is blank */

--- a/index.html
+++ b/index.html
@@ -171,6 +171,7 @@
                         <i class="fas fa-circle"></i>
                         <span>AI is typing...</span>
                     </span>
+                    <span id="char-count" class="char-count"></span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add character/word counter and disable send when empty
- remember last opened conversation via `localStorage`
- allow retry of failed AI responses
- add profile form validation and prevent deleting last profile
- improve conversation list preview and auto-scroll

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6876ead5c080832ab89887b8bd45ac6e