### PR TITLE
Implement memory toggle and prompt injection

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -609,6 +609,14 @@ body {
   animation: pulse 2s infinite;
 }
 
+.memory-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-primary);
+  margin-left: 4px;
+}
+
 @keyframes pulse {
   0%, 100% { opacity: 0.8; }
   50% { opacity: 0.5; }

--- a/index.html
+++ b/index.html
@@ -101,6 +101,7 @@
             <div class="header-title">
                 <h1 id="current-conversation-title">Vivica</h1>
                 <span class="status-indicator online"></span>
+                <span id="memory-indicator" class="memory-indicator" title="Memory enabled" style="display:none;"></span>
             </div>
             <div class="header-actions">
                 <button type="button" class="header-btn desktop-only" id="theme-toggle-btn" title="Toggle Theme" aria-label="Toggle Theme">
@@ -381,6 +382,9 @@
                     <label class="settings-label">Tags</label>
                     <input type="text" id="memory-tags" class="settings-input" placeholder="Enter tags separated by commas...">
                     <small class="settings-hint">Use tags to organize and search memories</small>
+                </div>
+                <div class="settings-group">
+                    <label><input type="checkbox" id="memory-enabled"> Enable memory in chat</label>
                 </div>
                 <div class="settings-group">
                     <label class="settings-label">Search Memories</label>


### PR DESCRIPTION
## Summary
- add memory indicator to header UI
- allow enabling/disabling memory snippets in memory modal
- inject saved memories into system prompts
- show memory state in header indicator

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687995cf19e0832a99aa28fb87030a6a