### PR TITLE
Fix welcome startup and sticky footer

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -893,7 +893,7 @@ pre code {
   padding: 20px;
   border-top: 1px solid var(--border);
   background: var(--bg-secondary);
-  position: bottom;
+  position: sticky;
   bottom: 0;
   z-index: 200;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -1409,14 +1409,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Initial render of conversations list
     await renderConversationsList();
 
-    const allConversations = await Storage.ConversationStorage.getAllConversations();
-    if (allConversations.length > 0) {
-        const lastId = parseInt(localStorage.getItem('lastConversationId') || '0');
-        const conv = allConversations.find(c => c.id === lastId) || allConversations[0];
-        await loadConversation(conv.id);
-    } else {
-        emptyState.style.display = 'flex';
-    }
+    // Always show the welcome screen on startup
+    emptyState.style.display = 'flex';
 
     // Voice mode setup
     const settings = await Storage.SettingsStorage.getSettings();


### PR DESCRIPTION
## Summary
- show the welcome screen instead of the last conversation on load
- keep the footer stuck to the bottom of the screen

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68799e3fc520832ab19fe95460329bc9