### PR TITLE
Refactor inline styles/scripts

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -741,6 +741,9 @@ body {
   color: var(--text-muted);
   opacity: 1;
 }
+.empty-icon img {
+  height: 200px;
+}
 
 .empty-title {
   font-size: 2rem;
@@ -1030,7 +1033,7 @@ kbd {
 }
 
 .typing-indicator {
-  display: inline-flex;
+  display: none;
   align-items: center;
   gap: 6px;
   color: var(--text-secondary);
@@ -1112,6 +1115,9 @@ kbd {
   padding: 24px;
   text-align: left;
   transition: background-color 0.3s ease;
+}
+.modal-content hr {
+  margin: 24px 0;
 }
 
 
@@ -1197,6 +1203,12 @@ kbd {
   color: var(--text-primary);
   font-size: 0.9rem;
   transition: all 0.2s ease;
+}
+
+.modal-actions {
+  margin-top: 20px;
+  display: flex;
+  gap: 8px;
 }
 
 .settings-input:focus {
@@ -1416,6 +1428,10 @@ kbd {
   transition: all 0.2s ease;
 }
 
+#delete-profile-btn {
+  display: none;
+}
+
 .delete-profile-btn:hover {
   background: rgba(255, 0, 0, 0.1);
   transform: scale(1.1);
@@ -1462,7 +1478,7 @@ kbd {
   height: 100%;
   background: rgba(0, 0, 0, 0.8);
   backdrop-filter: blur(4px);
-  display: flex;
+  display: none;
   align-items: center;
   justify-content: center;
   z-index: 3000;
@@ -1522,6 +1538,38 @@ kbd {
     transform: scale(4);
     opacity: 0;
   }
+}
+
+/* Utility Classes */
+.tools-container * {
+  box-sizing: border-box;
+}
+
+.section-heading {
+  margin-top: 0;
+  margin-bottom: 20px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #eee;
+  color: #555;
+}
+
+.input-action-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #f3f4f6;
+  border: none;
+  border-radius: 4px;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #4b5563;
+  margin-right: 8px;
+  transition: background 0.15s ease;
+}
+
+.input-action-button:hover {
+  background: #e5e7eb;
 }
 
 /* Scrollbar Styles */
@@ -1835,39 +1883,6 @@ body.light-mode .theme-purple {
     transform: translateY(20px);
 }
 
-/* Typing Indicator for AI message bubble */
-.typing-indicator {
-    display: flex;
-    align-items: center;
-    padding: 10px 15px;
-    border-radius: 18px;
-    background-color: var(--bg-tertiary);
-    max-width: 70%;
-    margin-bottom: 8px;
-    align-self: flex-start; /* AI message alignment */
-}
-
-.typing-dot {
-    width: 8px;
-    height: 8px;
-    background-color: var(--text-primary);
-    border-radius: 50%;
-    margin: 0 2px;
-    animation: typing-bounce 0.6s infinite alternate;
-}
-
-.typing-dot:nth-child(2) {
-    animation-delay: 0.2s;
-}
-
-.typing-dot:nth-child(3) {
-    animation-delay: 0.4s;
-}
-
-@keyframes typing-bounce {
-    from { transform: translateY(0); }
-    to { transform: translateY(-5px); }
-}
 
 /* Conversation item actions visibility on hover */
 .conversation-item-actions {
@@ -1968,12 +1983,18 @@ body.light-mode .theme-purple {
   max-height: 180px;
   overflow-y: auto;
   z-index: 2000;
+  display: none;
 }
 .model-dropdown-item {
   padding: 10px 14px;
   cursor: pointer;
   border-bottom: 1px solid var(--border-light);
   color: var(--text-primary);
+}
+#profile-model-selected {
+  font-size: 0.9em;
+  color: var(--text-muted);
+  display: none;
 }
 .model-dropdown-item:hover,
 .model-dropdown-item.active {

--- a/index.html
+++ b/index.html
@@ -10,39 +10,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-okaidia.min.css">
     <link rel="stylesheet" href="css/styles.css">
-    <style>
-        /* Clean up unused CSS classes */
-        .tools-container * {
-            box-sizing: border-box;
-        }
-        .section-heading {
-            margin-top: 0;
-            margin-bottom: 20px;
-            padding-bottom: 10px;
-            border-bottom: 1px solid #eee;
-            color: #555;
-        }
-        .input-action-button {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            background: #f3f4f6;
-            border: none;
-            border-radius: 4px;
-            padding: 8px 12px;
-            cursor: pointer;
-            font-size: 14px;
-            color: #4b5563;
-            margin-right: 8px;
-            transition: background 0.15s ease;
-        }
-        .input-action-button:hover {
-            background: #e5e7eb;
-        }
-        .settings-group {
-            margin-bottom: 20px;
-        }
-    </style>
+
 
     <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
@@ -116,7 +84,7 @@
         <div class="chat-body" id="chat-body">
             <div class="empty-state" id="empty-state">
                 <div class="empty-icon">
-                    <img id="logo-img" src="images/logo-defaultdark.png" alt="ChatBot Logo" style="height: 200px;" />
+                    <img id="logo-img" src="images/logo-defaultdark.png" alt="ChatBot Logo" />
                 </div>
                 <h2 class="empty-title">Welcome to Vivica</h2>
                 <p class="empty-text">Start a new conversation to begin</p>
@@ -139,7 +107,7 @@
                     </button>
                 </div>
             </div>
-            <span class="typing-indicator" id="typing-indicator" style="display: none;">
+            <span class="typing-indicator" id="typing-indicator">
                 <i class="fas fa-circle"></i>
                 <i class="fas fa-circle"></i>
                 <i class="fas fa-circle"></i>
@@ -265,7 +233,7 @@
             </div>
             <div class="modal-body">
                 <div id="profiles-list" class="custom-models-list"></div>
-                <hr style="margin:24px 0;">
+                <hr>
                 <form id="profile-form" class="settings-group" autocomplete="off">
                     <input type="hidden" id="profile-id">
                     <label class="settings-label" for="profile-name">Profile Name</label>
@@ -282,9 +250,9 @@
                         <input type="checkbox" id="model1-free-filter">
                         <label for="model1-free-filter">Show only free models</label>
                     </div>
-                    <div id="profile-model-dropdown" class="model-dropdown-list" style="display:none;max-height:160px;overflow:auto;border:1px solid var(--border);background:var(--bg-tertiary);border-radius:6px;z-index:99;position:relative;"></div>
+                    <div id="profile-model-dropdown" class="model-dropdown-list"></div>
                     <input type="hidden" id="profile-model" value="">
-                    <span id="profile-model-selected" style="font-size:0.9em;color:var(--text-muted);display:none;"></span>
+                    <span id="profile-model-selected"></span>
                     
                     <label class="settings-label" for="profile-system-prompt">System Prompt</label>
                     <textarea id="profile-system-prompt" class="settings-input" rows="3" placeholder="Describe this AI's persona/role..."></textarea>
@@ -299,13 +267,13 @@
                     <input type="number" id="profile-max-context" class="settings-input" value="20" min="1" max="50">
                     <small class="settings-hint">How many previous messages this persona will use for context (history/memory window)</small>
                     
-                    <div style="margin-top:20px;display:flex;gap:8px;">
+                    <div class="modal-actions">
                         <button type="submit" class="modal-btn primary-btn" id="save-profile-btn">
                             <i class="fas fa-save"></i>
                             Save Profile
                         </button>
                         <button type="button" class="modal-btn cancel-btn" id="cancel-profile-btn">Cancel</button>
-                        <button type="button" class="modal-btn danger-btn" id="delete-profile-btn" style="display:none">
+                        <button type="button" class="modal-btn danger-btn" id="delete-profile-btn">
                             <i class="fas fa-trash"></i>Delete
                         </button>
                     </div>
@@ -402,7 +370,7 @@
     </div>
 
     <!-- Loading Overlay -->
-    <div class="loading-overlay" id="loading-overlay" style="display: none;">
+    <div class="loading-overlay" id="loading-overlay">
         <div class="loading-spinner">
             <div class="spinner"></div>
             <p>Processing...</p>
@@ -414,61 +382,8 @@
     <script type="module" src="js/storage-wrapper.js"></script>
     <script type="module" src="js/android-bridge.js"></script>
 
-    <script>
-        // Helper functions for the UI
-        function insertQuickPrompt(prompt) {
-            document.getElementById('user-input').value = prompt;
-            document.getElementById('user-input').focus();
-        }
-
-        function closeModal(modalId) {
-            document.getElementById(modalId).style.display = 'none';
-        }
-
-        // Add smooth scrolling and modern interactions
-        document.addEventListener('DOMContentLoaded', function() {
-            // Add ripple effect to buttons
-            const buttons = document.querySelectorAll('button, .quick-action-btn');
-            buttons.forEach(button => {
-                button.addEventListener('click', function(e) {
-                    const ripple = document.createElement('span');
-                    ripple.classList.add('ripple');
-                    this.appendChild(ripple);
-                    
-                    const rect = this.getBoundingClientRect();
-                    const size = Math.max(rect.width, rect.height);
-                    ripple.style.width = ripple.style.height = size + 'px';
-                    ripple.style.left = (e.clientX - rect.left - size / 2) + 'px';
-                    ripple.style.top = (e.clientY - rect.top - size / 2) + 'px';
-                    
-                    setTimeout(() => {
-                        ripple.remove();
-                    }, 600);
-                });
-            });
-
-            // Auto-resize textarea
-            const textareas = document.querySelectorAll('textarea');
-            textareas.forEach(textarea => {
-                textarea.addEventListener('input', function() {
-                    this.style.height = 'auto';
-                    this.style.height = this.scrollHeight + 'px';
-                });
-            });
-        });
-
-        // Global error handling
-        window.addEventListener('error', (event) => {
-            console.error('Global error:', event.error || event.message);
-            if (window.showToast) {
-                window.showToast('Error: ' + (event.error?.message || event.message), 'error', 5000);
-            }
-        });
-        
-    </script>
-	<script type="module" src="js/android-bridge.js"></script>
-	<script src="js/theme-toggle.js"></script>
-	<script type="module" src="js/main.js"></script>
+    <script type="module" src="js/theme-toggle.js"></script>
+    <script type="module" src="js/main.js"></script>
 
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -130,6 +130,48 @@ function showToast(message, type = 'info', duration = 3000) {
 // Expose globally for other modules or pages
 window.showToast = showToast;
 
+// Inserts a quick prompt into the user input field
+function insertQuickPrompt(prompt) {
+    userInput.value = prompt;
+    userInput.focus();
+}
+window.insertQuickPrompt = insertQuickPrompt;
+
+// Apply ripple effects to all buttons
+function addRippleEffects() {
+    document.querySelectorAll('button, .quick-action-btn').forEach(btn => {
+        btn.addEventListener('click', e => {
+            const ripple = document.createElement('span');
+            ripple.classList.add('ripple');
+            btn.appendChild(ripple);
+            const rect = btn.getBoundingClientRect();
+            const size = Math.max(rect.width, rect.height);
+            ripple.style.width = ripple.style.height = size + 'px';
+            ripple.style.left = (e.clientX - rect.left - size / 2) + 'px';
+            ripple.style.top = (e.clientY - rect.top - size / 2) + 'px';
+            setTimeout(() => ripple.remove(), 600);
+        });
+    });
+}
+
+// Auto resize all textareas on input
+function enableAutoResize() {
+    document.querySelectorAll('textarea').forEach(t => {
+        t.addEventListener('input', function () {
+            this.style.height = 'auto';
+            this.style.height = this.scrollHeight + 'px';
+        });
+    });
+}
+
+// Global error handler
+window.addEventListener('error', (event) => {
+    console.error('Global error:', event.error || event.message);
+    if (window.showToast) {
+        window.showToast('Error: ' + (event.error?.message || event.message), 'error', 5000);
+    }
+});
+
 // Function to safely render markdown with proper line breaks
 function renderMarkdown(content) {
     // First replace literal newlines with markdown line breaks
@@ -1374,6 +1416,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     sendBtn.disabled = true;
     if (charCountSpan) charCountSpan.textContent = '0w / 0c';
     updateMemoryIndicator();
+    addRippleEffects();
+    enableAutoResize();
     adjustChatLayout();
     window.addEventListener('resize', adjustChatLayout);
     if (window.innerWidth <= 768) {


### PR DESCRIPTION
## Summary
- migrate inline styles to CSS and clean up duplicates
- move inline scripts into main.js and expose quick prompts
- add ripple and textarea auto-resize features
- remove unused duplicate script tags

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687b51ca20c4832a9ed7741162af03f1