### PR TITLE
Add profile dropdown and memory prompt integration

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2083,3 +2083,16 @@ body.light-mode .theme-purple {
     background: var(--bg-hover);
     color: var(--accent-primary);
 }
+
+.profile-select {
+    padding: 6px 10px;
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    font-size: 0.9rem;
+}
+.profile-select:focus {
+    outline: none;
+    border-color: var(--accent-primary);
+}

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
                 <i class="fas fa-bars"></i>
             </button>
             <div class="header-title">
-                <h1 id="current-conversation-title">Vivica</h1>
+                <select id="profile-select" class="profile-select"></select>
                 <span class="status-indicator online"></span>
             </div>
             <div class="header-actions">

--- a/js/voice-animation.js
+++ b/js/voice-animation.js
@@ -62,25 +62,24 @@ class VoiceAnimation {
       touch-action: none;
     `;
     
-    // Create name display
-    const nameDiv = document.createElement('div');
-    nameDiv.className = 'vivica-name';
-    nameDiv.textContent = 'VIVICA';
-    nameDiv.style.cssText = `
+    this.profileSelect = document.createElement('select');
+    this.profileSelect.id = 'voice-profile-select';
+    this.profileSelect.className = 'profile-select';
+    this.profileSelect.style.cssText = `
       position: absolute;
       bottom: 40px;
       left: 50%;
       transform: translateX(-50%);
-      font-size: clamp(20px, 5vw, 32px);
-      font-weight: bold;
-      letter-spacing: 3px;
-      opacity: 0.9;
-      text-shadow: 0 0 20px rgba(255,255,255,0.5);
-      pointer-events: none;
+      padding: 8px 12px;
+      background: rgba(0,0,0,0.6);
+      color: white;
+      border-radius: 8px;
+      border: 1px solid rgba(255,255,255,0.3);
+      pointer-events: auto;
     `;
 
     this.animationContainer.appendChild(this.canvas);
-    this.animationContainer.appendChild(nameDiv);
+    this.animationContainer.appendChild(this.profileSelect);
     this.animationContainer.appendChild(closeBtn);
     document.body.appendChild(this.animationContainer);
 


### PR DESCRIPTION
## Summary
- inject memory into prompts before sending to the LLM
- allow switching profiles via dropdown in header and voice orb
- keep selected profile in localStorage and sync with voice mode
- style profile dropdowns

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687b5ef67b94832a8d4ca60cf1663a03