### PR TITLE
Add conversation summarization feature

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2112,3 +2112,20 @@ body.light-mode .theme-purple {
     outline: none;
     border-color: var(--accent-primary);
 }
+
+/* Summarize & Save button */
+.summarize-btn {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  color: var(--text-primary);
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  margin-left: 8px;
+  transition: background 0.2s ease;
+}
+
+.summarize-btn:hover {
+  background: var(--bg-hover);
+}

--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
                             <button type="button" class="input-btn" id="upload-btn" onclick="document.getElementById('file-upload').click()" aria-label="Upload file" title="Upload file">
                                 <i class="fas fa-paperclip"></i>
                             </button>
-                            <button type="button" class="input-btn" id="clear-btn" aria-label="Clear input" title="Clear input">
+                    <button type="button" class="input-btn" id="clear-btn" aria-label="Clear input" title="Clear input">
                                 <i class="fas fa-trash-alt"></i>
                             </button>
                         </div>
@@ -143,6 +143,7 @@
                 </div>
                 <div class="input-hint">
                     <span id="char-count" class="char-count"></span>
+                    <button type="button" class="summarize-btn" id="summarize-save-btn">Summarize &amp; Save</button>
                 </div>
             </div>
         </div>

--- a/js/main.js
+++ b/js/main.js
@@ -54,6 +54,7 @@ const voiceModeToggleBtn = document.getElementById('voice-mode-toggle-btn');
 const themeSelect = document.getElementById('theme-select');
 const darkModeToggle = document.getElementById('dark-mode-toggle');
 const currentThemeLabel = document.getElementById('current-theme-label');
+const summarizeBtn = document.getElementById('summarize-save-btn');
 
 // Mobile touch variables for sidebar swipe
 let touchStartX = null;
@@ -1393,6 +1394,74 @@ function copyExportContent() {
     copyToClipboard(exportContentTextarea.value);
 }
 
+/**
+ * Summarizes the current conversation using the active profile and saves the result to memory.
+ */
+async function summarizeAndSaveConversation() {
+    if (!currentConversationId) {
+        showToast('No messages to summarize.', 'info');
+        return;
+    }
+    const messages = await Storage.MessageStorage.getMessagesByConversationId(currentConversationId);
+    if (!messages.length) {
+        showToast('No messages to summarize.', 'info');
+        return;
+    }
+    showTypingIndicator(true);
+    try {
+        const settings = await Storage.SettingsStorage.getSettings();
+        const apiKey = settings?.apiKey1;
+        if (!apiKey) {
+            showToast('OpenRouter API Key is not set in settings.', 'error', 5000);
+            return;
+        }
+        const profile = window.currentProfile || (currentProfileId ? await Storage.ProfileStorage.getProfile(currentProfileId) : null);
+        const model = profile?.model || 'mistralai/mistral-7b-instruct';
+        const temperature = profile?.temperature !== undefined ? profile.temperature : 0.7;
+        const maxTokens = Math.min(profile?.maxTokens || 500, 1000);
+        const history = messages.map(m => `${m.sender === 'user' ? 'User' : 'Assistant'}: ${m.content}`).join('\n');
+        const reqMessages = [
+            { role: 'system', content: 'Summarize the following conversation for long-term memory. Focus on the user\u2019s goals, tone, emotional state, and any significant tasks, themes, or preferences discussed.' },
+            { role: 'user', content: history }
+        ];
+        const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${apiKey}`,
+                'Content-Type': 'application/json',
+                'HTTP-Referer': window.location.origin,
+                'X-Title': 'Vivica Chat App'
+            },
+            body: JSON.stringify({
+                model,
+                messages: reqMessages,
+                temperature,
+                max_tokens: maxTokens
+            })
+        });
+        if (!response.ok) {
+            const err = await response.json();
+            throw new Error(err.error?.message || 'Request failed');
+        }
+        const data = await response.json();
+        const summary = data.choices?.[0]?.message?.content?.trim();
+        if (!summary) throw new Error('No summary returned');
+        await Storage.MemoryStorage.addMemory({
+            content: summary,
+            tags: ['summary', 'conversation'],
+            profileId: profile?.id || null,
+            pinned: false,
+            timestamp: Date.now()
+        });
+        showToast('Conversation summarized and saved to memory.', 'success');
+    } catch (err) {
+        debugLog(`Summary error: ${err.message}`, 'error');
+        showToast('Failed to summarize conversation.', 'error');
+    } finally {
+        showTypingIndicator(false);
+    }
+}
+
 // --- Event Listeners ---
 
 // Scroll to bottom button logic
@@ -1641,6 +1710,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     closeExportModalBtn.addEventListener('click', () => closeModal(exportModal));
     copyExportBtn.addEventListener('click', copyExportContent);
+    summarizeBtn.addEventListener('click', summarizeAndSaveConversation);
 
     // File upload and clear input
     fileUploadInput.addEventListener('change', handleFileUpload);


### PR DESCRIPTION
## Summary
- introduce "Summarize & Save" button in chat footer
- style new button
- fetch a summary of the active conversation via OpenRouter and store it in IndexedDB memory

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687b64320574832a942cb01a2393a3ba