### PR TITLE
Fix voice mode API key usage

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -769,7 +769,7 @@ async function getAIResponse(userQuery) {
         const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
             method: 'POST',
             headers: {
-                'Authorization': `Bearer ${vivicaVoiceModeConfig.apiKey}`,
+                'Authorization': `Bearer ${apiKey}`,
                 'Content-Type': 'application/json',
                 'Accept': 'text/event-stream',
                 'HTTP-Referer': window.location.origin, // Important for OpenRouter


### PR DESCRIPTION
## Summary
- use stored API key when requesting OpenRouter

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687cf8cbfe30832a9422c488b3927475