### PR TITLE
Fix DataError when profiles lack an ID

### DIFF
--- a/js/db-utils.js
+++ b/js/db-utils.js
@@ -118,6 +118,10 @@ export async function add(storeName, item) {
  * @returns {Promise<object | undefined>} A promise that resolves with the retrieved item, or undefined if not found.
  */
 export async function get(storeName, key) {
+    if (key === undefined || key === null) {
+        console.warn(`DB: get called on ${storeName} with invalid key`, key);
+        return undefined;
+    }
     const db = await initDB();
     const tx = db.transaction(storeName, 'readonly');
     const store = tx.objectStore(storeName);

--- a/js/storage-wrapper.js
+++ b/js/storage-wrapper.js
@@ -217,6 +217,9 @@ export const ProfileStorage = {
      */
     getProfile: async (id) => {
         try {
+            if (id === undefined || id === null) {
+                return undefined;
+            }
             return await get(STORES.PROFILES, id);
         } catch (error) {
             console.error('ProfileStorage: Error getting profile:', error);


### PR DESCRIPTION
## Summary
- handle invalid keys in DB `get` helper
- allow `ProfileStorage.getProfile()` to accept undefined IDs

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687d3daf0404832aa2dd734d13168640