### PR TITLE
Fix welcome screen trigger and polish modals

### DIFF
--- a/css/modals.css
+++ b/css/modals.css
@@ -268,5 +268,37 @@ textarea:focus {
   color: #fff;
 }
 
+/* Profile snippet truncation */
+.profile-snippet {
+  font-size: 0.92em;
+  color: var(--text-muted);
+  margin-bottom: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Consistent modal buttons */
+.modal-btn {
+  padding: 6px 12px;
+  font-size: 0.92rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.modal-btn.primary-btn {
+  background: var(--accent-primary);
+  color: #fff;
+}
+.modal-btn.cancel-btn {
+  background: var(--bg-tertiary);
+}
+.modal-btn.danger-btn {
+  background: var(--danger);
+  color: #fff;
+}
+
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -1546,6 +1546,9 @@ async function renderProfilesList() {
     }
 
     profiles.forEach(profile => {
+        const snippet = profile.systemPrompt.length > 120
+            ? profile.systemPrompt.slice(0, 120) + '…'
+            : profile.systemPrompt;
         profilesListDiv.innerHTML += `
   <div class="profile-card">
     <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:2px;">
@@ -1558,9 +1561,7 @@ async function renderProfilesList() {
     <div style="font-size:0.93em;color:var(--text-secondary);margin-bottom:1px;">
       Model: ${profile.model}
     </div>
-    <div style="font-size:0.92em;color:var(--text-muted);margin-bottom:2px;">
-      ${profile.systemPrompt}
-    </div>
+    <div class="profile-snippet">${snippet}</div>
     <div style="font-size:0.85em;color:var(--text-muted);">
       Temp: ${profile.temperature} &nbsp; Max Tokens: ${profile.maxTokens}
     </div>
@@ -1851,7 +1852,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         m.style.display = 'none';
     });
 
-    const homeTrigger = document.getElementById('sidebar-home');
+    const homeTrigger = document.getElementById('sidebar-home-trigger');
     homeTrigger?.addEventListener('click', async (e) => {
         e.preventDefault();
         e.stopPropagation();


### PR DESCRIPTION
## Summary
- hook sidebar header click to the correct ID so the welcome screen shows
- truncate long system prompts in profile cards
- add styles for modal buttons and profile snippets

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687d5bfd1bfc832a80695f9687841e81